### PR TITLE
#37 lazyloadを削除

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,13 +275,13 @@
 					<div id="sketch-grid">
 						<div id="sketchback">
 							<div id="sketch-box">
-								<div id="sketchimg-one" class="wow zoomIn animated shakeimg"><i class="thumb-pin"></i><img class="lazyload" data-src="images/stylesketch_3.jpg"></div>
-								<div id="sketchimg-two" class="wow rotateInUpRight animated shakeimg"><img class="lazyload" data-src="images/stylesketch_2.jpg"></div>
-								<div id="sketchimg-three" class="wow rotateInUpRight animated shakeimg"><img class="lazyload" data-src="images/stylesketch_1.jpg"></div>
-								<div id="sketchimg-four" class="wow rotateInUpRight animated shakeimg"><img class="lazyload" data-src="images/IMG_2900-1.jpg"></div>
-								<div id="sketchimg-five" class="wow rotateInUpRight animated shakeimg"><img class="lazyload" data-src="images/bagsketch_1.jpg"></div>
-								<div id="sketchimg-six" class="wow rotateInUpRight animated shakeimg"><img class="lazyload" data-src="images/bagsketch_2.jpg"></div>
-								<div id="sketchimg-seven" class="wow rotateInUpRight animated shakeimg"><img class="lazyload" data-src="images/bagsketch_3.jpg"></div>
+								<div id="sketchimg-one" class="wow zoomIn animated shakeimg"><i class="thumb-pin"></i><img src="images/stylesketch_3.jpg"></div>
+								<div id="sketchimg-two" class="wow rotateInUpRight animated shakeimg"><img src="images/stylesketch_2.jpg"></div>
+								<div id="sketchimg-three" class="wow rotateInUpRight animated shakeimg"><img src="images/stylesketch_1.jpg"></div>
+								<div id="sketchimg-four" class="wow rotateInUpRight animated shakeimg"><img src="images/IMG_2900-1.jpg"></div>
+								<div id="sketchimg-five" class="wow rotateInUpRight animated shakeimg"><img src="images/bagsketch_1.jpg"></div>
+								<div id="sketchimg-six" class="wow rotateInUpRight animated shakeimg"><img src="images/bagsketch_2.jpg"></div>
+								<div id="sketchimg-seven" class="wow rotateInUpRight animated shakeimg"><img src="images/bagsketch_3.jpg"></div>
 							</div>
 						</div>	
 					</div>		


### PR DESCRIPTION
#37 の問題がlazyloadを削除することによって直ることがわかりました。
おそらく画像の読み込みを遅延させたので画像の大きさが正しく認識されず、位置がずれたと思われます。
ご迷惑をおかけして申し訳ございません。